### PR TITLE
Fix/error handling

### DIFF
--- a/cypress/e2e/new-task-spec.cy.js
+++ b/cypress/e2e/new-task-spec.cy.js
@@ -62,7 +62,9 @@ describe('new tasks (categories) page spec', () => {
           headers: { 'content-type': 'application/json' },
         }).as(`failed${categoryURL}request`);
         cy.visit(`localhost:3000/${categoryURL}`)
-        cy.wait(`@failed${categoryURL}request`).get('.task-card').contains('h1', 'Loading...');
+        cy.wait('@taskFetch')
+        cy.wait('@getSavedTasks')
+        cy.wait(`@failed${categoryURL}request`).get('.task-card').contains('p', 'We apologize!');
       });
     });
   });

--- a/src/components/ErrorMessage/ErrorMessage.js
+++ b/src/components/ErrorMessage/ErrorMessage.js
@@ -1,9 +1,9 @@
 import './ErrorMessage.css'
 
-const ErrorMessage = () => {
+const ErrorMessage = ({message}) => {
   return (
   <p className="error-message">
-    Sorry, you've saved all the tasks in this category.
+    {message}
   </p>
   )
 }

--- a/src/components/SelectTaskView/SelectTaskView.js
+++ b/src/components/SelectTaskView/SelectTaskView.js
@@ -24,15 +24,23 @@ const SelectTaskView = ({savedTasks, setSavedTasks, error, setError}) => {
   
   useEffect(() => {
     fetchAllTasks().then(
-      data => setTasks(data)
-    ).catch(error => setError({ error: true, response: error }))
+      data => {
+        setTasks(data)
+        setWaitingForData(false);
+      }
+    ).catch(error => {
+      setWaitingForData(false);
+      setError({ error: true, response: error })
+    })
   }, [])
 
   const fetchTasks = (category) => {
     if (category !== 'all') {
       fetchCategoryTask(category).then(
         data => setCurrentTasks(data)
-      ).catch(error => setError({ error: true, response: error }))
+      ).catch(error => {
+        setError({ error: true, response: error })
+      })
     } else {
   let allTasks = [];
   tasks.forEach((task) => {
@@ -74,14 +82,6 @@ const getCurrentTask = (tasks) => {
   processedTask.category = humanizeCategory(unprocessedTask.category);
   setCurrentTask(processedTask);
 };
-
-useEffect(() => {
-  if (currentTask) {
-    setWaitingForData(false);
-  } else {
-    setWaitingForData(true);
-  }
-}, [currentTask]);
 
 useEffect(() => {
   if (unseenTasks.length) {
@@ -169,7 +169,8 @@ return (
     <div className="task-card">
       {!tasksToShow && waitingForData && <h1>Loading...</h1>}
       {(tasksToShow && tasks.length !== 0 && !error.error) && <p className='task-text'>{currentTask.task}</p>}
-      {(!tasksToShow && !waitingForData) && <ErrorMessage />}
+      {(!tasksToShow && !waitingForData) && <ErrorMessage message={"You have saved all tasks. No more tasks to show."}/>}
+      {(!tasksToShow && waitingForData && error.error) && <ErrorMessage message={"Something went wrong."}/>}
       {error.error && <p className='error-message'>{`We apologize! ${error.response}. Please try again later.`}</p>}
       <p className={displaySavedResponse ? 'save-display saved-confirmation' : 'saved-confirmation'}>
         {saveResponse}

--- a/src/components/SelectTaskView/SelectTaskView.js
+++ b/src/components/SelectTaskView/SelectTaskView.js
@@ -170,9 +170,8 @@ return (
     <div className="task-card">
       {!tasksToShow && waitingForData && <h1>Loading...</h1>}
       {(tasksToShow && tasks.length !== 0 && !error.error) && <p className='task-text'>{currentTask.task}</p>}
-      {(!tasksToShow && !waitingForData) && <ErrorMessage message={"You have saved all tasks. No more tasks to show."}/>}
-      {(!tasksToShow && waitingForData && error.error) && <ErrorMessage message={"Something went wrong."}/>}
-      {error.error && <p className='error-message'>{`We apologize! ${error.response}. Please try again later.`}</p>}
+      {(!tasksToShow && !waitingForData && !error.error) && <ErrorMessage message={"You have saved all tasks. No more tasks to show."}/>}
+      {(!tasksToShow && !waitingForData && error.error) && <ErrorMessage message={`We apologize! ${error.response}. Please try again later.`}/>}
       <p className={displaySavedResponse ? 'save-display saved-confirmation' : 'saved-confirmation'}>
         {saveResponse}
       </p>

--- a/src/components/SelectTaskView/SelectTaskView.js
+++ b/src/components/SelectTaskView/SelectTaskView.js
@@ -20,7 +20,8 @@ const SelectTaskView = ({savedTasks, setSavedTasks, error, setError}) => {
   const [saveSuccessful, setSaveSuccessful] = useState(false);
   const [saveResponse, setSaveResponse] = useState('');
   const [saveIcon, setSaveIcon] = useState(savePurpleIcon);
-
+  const [waitingForData, setWaitingForData] = useState(true);
+  
   useEffect(() => {
     fetchAllTasks().then(
       data => setTasks(data)
@@ -73,6 +74,14 @@ const getCurrentTask = (tasks) => {
   processedTask.category = humanizeCategory(unprocessedTask.category);
   setCurrentTask(processedTask);
 };
+
+useEffect(() => {
+  if (currentTask) {
+    setWaitingForData(false);
+  } else {
+    setWaitingForData(true);
+  }
+}, [currentTask]);
 
 useEffect(() => {
   if (unseenTasks.length) {
@@ -158,9 +167,9 @@ return (
   <div className="new-task-page">
     <h1 className="category-title">{currentTask.category}</h1>
     <div className="task-card">
-      {tasksToShow === false && <h1>Loading...</h1>}
+      {!tasksToShow && waitingForData && <h1>Loading...</h1>}
       {(tasksToShow && tasks.length !== 0 && !error.error) && <p className='task-text'>{currentTask.task}</p>}
-      {(!tasksToShow && error.error) && <ErrorMessage />}
+      {(!tasksToShow && !waitingForData) && <ErrorMessage />}
       {error.error && <p className='error-message'>{`We apologize! ${error.response}. Please try again later.`}</p>}
       <p className={displaySavedResponse ? 'save-display saved-confirmation' : 'saved-confirmation'}>
         {saveResponse}


### PR DESCRIPTION
What I did:
This PR closes #26 
I refactored the display messages for when the individual task is loading, when all tasks are saved, and when there's a fetch error.
Also refactored the tests and added a couple of waits. All net requests are consistently being  stubbed.

Did this break anything?

- [x] No
- [ ]  Yes

Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  Refactor(DRY-ing up/ reorganizing code, etc.)
- [ ]  Super small fix (Corrected a typo, removed a comment, etc.)
- [ ]  Skip all the other stuff and briefly explain the fix.

Checklist:

- [x]  If this code needs to be tested, all tests are passing
- [x]  The code runs locally
- [ ]  There are comments where clarification/ organization is needed
- [x]  The code is DRY. If it's not, I tried my best
- [x]  I reviewed my code before pushing

